### PR TITLE
correct indent error in get_zipped_data in code from chp8

### DIFF
--- a/code/chp7-cleanup/import_csv.py
+++ b/code/chp7-cleanup/import_csv.py
@@ -13,6 +13,6 @@ for data_dict in data_rows:
         for header_dict in header_rows:
             if dkey in header_dict.values():
                 new_row[header_dict.get('Label')] = dval
-                new_rows.append(new_row)
+    new_rows.append(new_row)
 
 print new_rows[0]

--- a/code/chp8-cleanup/get_zipped_data.py
+++ b/code/chp8-cleanup/get_zipped_data.py
@@ -33,7 +33,7 @@ def get_clean_rows():
         for i, d in enumerate(row):
             if i not in skip_index:
                 new_row.append(d)
-            new_data.append(new_row)
+        new_data.append(new_row)
     return header_rows, new_data
 
 


### PR DESCRIPTION
I think the indent of the original code is wrong, which will produce the length of output is much larger than the original data length. And the error will cause memory error while running **get_zipped_data()** or making the computer go down.